### PR TITLE
Fix PostCSS config for CommonJS execution

### DIFF
--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,4 +1,4 @@
-export default {
+module.exports = {
   plugins: {
     tailwindcss: {},
     autoprefixer: {}


### PR DESCRIPTION
## Summary
- replace the ES module export in postcss.config.js with CommonJS module.exports so Node 18 can load it without a package.json type declaration

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d57bbe7e048328a7ad9e3ea74670bf