### PR TITLE
Fix Alembic configuration for DATABASE_URL environment variable

### DIFF
--- a/backend/alembic.ini
+++ b/backend/alembic.ini
@@ -1,6 +1,10 @@
 [alembic]
 script_location = migrations
-sqlalchemy.url = %(DATABASE_URL)s
+# The actual database URL is provided at runtime via the DATABASE_URL
+# environment variable inside migrations/env.py.  Leaving this value empty
+# avoids ConfigParser interpolation errors when the environment variable is
+# not available during configuration parsing.
+sqlalchemy.url =
 prepend_sys_path = .
 
 [loggers]


### PR DESCRIPTION
## Summary
- update Alembic configuration to avoid ConfigParser interpolation errors when DATABASE_URL is provided via the environment

## Testing
- no tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d580fb510883289bd385c88240d965